### PR TITLE
Implement consts and globals

### DIFF
--- a/src/python/ast_nodes.py
+++ b/src/python/ast_nodes.py
@@ -180,4 +180,11 @@ class ImplDeclr(Declr):
 class VariableDeclr(Declr):
     name: Identifier
     typ: Type | None
+    value: Expr | None
+
+
+@dataclass
+class ConstDeclr(Declr):
+    name: Identifier
+    typ: Type | None
     value: Expr

--- a/src/python/compiler.py
+++ b/src/python/compiler.py
@@ -87,10 +87,17 @@ class Compiler:
                 self.refs[id(node)] = obj
             case ir.Ref():
                 typ = self.build(node.typ)
-                ptr = self.builder.build_alloca(typ, node.name)
+                if node.is_global:
+                    ptr = self.module.add_global(typ, node.name)
+                else:
+                    ptr = self.builder.build_alloca(typ, node.name)
                 if isinstance(node, ir.ConstRef):
                     value = self.build(node.value)
-                    self.builder.build_store(value, ptr)
+                    if node.is_global:
+                        # TODO: `value` needs to be comptime
+                        ptr.set_initializer(value)
+                    else:
+                        self.builder.build_store(value, ptr)
                 return ptr
         return obj
 

--- a/src/python/compiler.py
+++ b/src/python/compiler.py
@@ -88,6 +88,9 @@ class Compiler:
             case ir.Ref():
                 typ = self.build(node.typ)
                 ptr = self.builder.build_alloca(typ, node.name)
+                if isinstance(node, ir.ConstRef):
+                    value = self.build(node.value)
+                    self.builder.build_store(value, ptr)
                 return ptr
         return obj
 

--- a/src/python/interpreter.py
+++ b/src/python/interpreter.py
@@ -123,6 +123,9 @@ class Interpreter:
                         struct = self.eval_node(node.parent).value
                         obj = struct.value[node.name]
                     self.refs[id(node)] = obj
+                case ir.ConstRef():
+                    value = self.eval_node(node.value)
+                    obj = StaVariable(node.name, value)
                 case ir.Ref():
                     obj = StaVariable(node.name)
             return obj

--- a/src/python/ir.py
+++ b/src/python/ir.py
@@ -148,6 +148,8 @@ class IRNoder:
                 self.make_impl_declr(target, interface, methods)
             case ast.VariableDeclr(name, typ, value):
                 self.make_variable_declr(name, typ, value)
+            case ast.ConstDeclr(name, typ, value):
+                self.make_const_declr(name, typ, value)
             case _:
                 assert False, f"Unexpected declr {node}"
 
@@ -410,6 +412,16 @@ class IRNoder:
             value = self.make_expr(value)
             ref.values.append(value)
             self.instrs.append(ir.Assign(ref, value))
+
+    def make_const_declr(self, name, typ, value):
+        name = name.value
+        type_hint = None
+        if typ is not None:
+            type_hint = self.make_type(typ)
+        value = self.make_expr(value)
+        ref = ir.ConstRef(name, value, typ=type_hint)
+        self.scope.declare(name, ref)
+        self.instrs.append(ir.Declare(ref))
 
 
 if __name__ == "__main__":

--- a/src/python/ir.py
+++ b/src/python/ir.py
@@ -18,6 +18,7 @@ class IRNoder:
         self.current_func = None
         self.blocks = {}
         self.error_handler = error_handler
+        self.global_block = None
 
     def error(self, msg):
         # add position info
@@ -71,6 +72,7 @@ class IRNoder:
                 self.make_declr(node)
             case ast.Program(declrs):
                 block = self.block
+                self.global_block = block
                 for declr in declrs:
                     self.make_declr(declr)
                 return ir.Program(block)
@@ -423,6 +425,10 @@ class IRNoder:
         ref = ir.ConstRef(name, value, typ=type_hint)
         self.scope.declare(name, ref)
         self.instrs.append(ir.Declare(ref))
+        if self.block == self.global_block:
+            ref.is_global = True
+            # TODO: this check should be on all declarations
+            #       maybe a `self.declare()` helper is needed
 
 
 if __name__ == "__main__":

--- a/src/python/ir.py
+++ b/src/python/ir.py
@@ -292,6 +292,7 @@ class IRNoder:
 
     def make_assignment_stmt(self, target, value):
         target = self.make_expr(target, load=False)
+        assert not target.is_const, "Cannot assign to const"
         value = self.make_expr(value)
         target.values.append(value)
         self.instrs.append(ir.Assign(target, value))

--- a/src/python/ir_nodes.py
+++ b/src/python/ir_nodes.py
@@ -270,7 +270,7 @@ class IRPrinter:
                 string += f"{ir.name}{{{fields}}}"
             case ConstRef(name, value):
                 string += f"CONST {name} = {self._to_string(value)}"
-                return string # avoids duplication of type
+                return string  # avoids duplication of type
             case StructLiteral():
                 fields = ', '.join(self._to_string(f) for f in ir.fields.values())
                 string = f"{{{fields}}}"

--- a/src/python/ir_nodes.py
+++ b/src/python/ir_nodes.py
@@ -31,6 +31,7 @@ class StructLiteral(Object):
 class Ref(Object):
     is_expr = True
     is_global = False
+    is_const = False
     name: str
     values: list = field(default_factory=list, kw_only=True)
     members: dict = field(default_factory=dict, kw_only=True)

--- a/src/python/ir_nodes.py
+++ b/src/python/ir_nodes.py
@@ -30,6 +30,7 @@ class StructLiteral(Object):
 @dataclass
 class Ref(Object):
     is_expr = True
+    is_global = False
     name: str
     values: list = field(default_factory=list, kw_only=True)
     members: dict = field(default_factory=dict, kw_only=True)

--- a/src/python/ir_nodes.py
+++ b/src/python/ir_nodes.py
@@ -268,6 +268,7 @@ class IRPrinter:
                 string += f"{ir.name}{{{fields}}}"
             case ConstRef(name, value):
                 string += f"CONST {name} = {self._to_string(value)}"
+                return string # avoids duplication of type
             case StructLiteral():
                 fields = ', '.join(self._to_string(f) for f in ir.fields.values())
                 string = f"{{{fields}}}"

--- a/src/python/ir_nodes.py
+++ b/src/python/ir_nodes.py
@@ -102,6 +102,12 @@ class StructRef(Type):
 
 
 @dataclass
+class ConstRef(Ref):
+    is_const = True
+    value: Object
+
+
+@dataclass
 class Declare(Instruction):
     ref: Ref
 
@@ -260,6 +266,8 @@ class IRPrinter:
             case StructRef():
                 fields = ', '.join(ir.fields)
                 string += f"{ir.name}{{{fields}}}"
+            case ConstRef(name, value):
+                string += f"CONST {name} = {self._to_string(value)}"
             case StructLiteral():
                 fields = ', '.join(self._to_string(f) for f in ir.fields.values())
                 string = f"{{{fields}}}"

--- a/src/python/lexer.py
+++ b/src/python/lexer.py
@@ -12,7 +12,7 @@ TokenType = Enum("TokenType", [
     "LEFT_BRACKET", "RIGHT_BRACKET",
     "LEFT_CURLY", "RIGHT_CURLY", "LEFT_SQUARE", "RIGHT_SQUARE",
     "IF", "ELSE", "WHILE", "RETURN",
-    "VAR", "FUNC", "STRUCT", "INTERFACE", "IMPL",
+    "VAR", "CONST", "FUNC", "STRUCT", "INTERFACE", "IMPL",
 ])
 Token = namedtuple("Token", ["typ", "lexeme", "pos"])
 
@@ -37,6 +37,7 @@ KEYWORDS = {
     "while": T.WHILE,
     "return": T.RETURN,
     "var": T.VAR,
+    "const": T.CONST,
     "fn": T.FUNC,
     "struct": T.STRUCT,
     "interface": T.INTERFACE,

--- a/src/python/parser.py
+++ b/src/python/parser.py
@@ -86,6 +86,8 @@ class Parser:
             return self.parse_impl_declr()
         elif self.check(T.VAR):
             return self.parse_variable_declr()
+        elif self.check(T.CONST):
+            return self.parse_const_declr()
         else:
             self.error("Failed to parse declaration")
             self.advance(T.FUNC, T.STRUCT, T.VAR)
@@ -166,6 +168,15 @@ class Parser:
             value = self.parse_expression()
         self.expect(T.SEMICOLON)
         return ast.VariableDeclr(name, typ, value)
+
+    def parse_const_declr(self):
+        self.expect(T.CONST)
+        name = self.parse_identifier()
+        typ = None
+        self.expect(T.EQUALS)
+        value = self.parse_expression()
+        self.expect(T.SEMICOLON)
+        return ast.ConstDeclr(name, typ, value)
 
     def parse_type(self):
         if self.check(T.IDENTIFIER):

--- a/src/python/parser.py
+++ b/src/python/parser.py
@@ -202,7 +202,7 @@ class Parser:
         return ast.Block(statements)
 
     def parse_statement(self):
-        if self.check(T.FUNC, T.VAR):
+        if self.check(T.FUNC, T.VAR, T.CONST):
             return ast.DeclrStmt(self.parse_declaration())
         elif self.check(T.IF):
             return self.parse_if()

--- a/src/python/parser.py
+++ b/src/python/parser.py
@@ -173,6 +173,8 @@ class Parser:
         self.expect(T.CONST)
         name = self.parse_identifier()
         typ = None
+        if not self.check(T.EQUALS):
+            typ = self.parse_type()
         self.expect(T.EQUALS)
         value = self.parse_expression()
         self.expect(T.SEMICOLON)

--- a/src/python/type_checker.py
+++ b/src/python/type_checker.py
@@ -203,6 +203,9 @@ class TypeChecker:
                 assert value, f"{node.name} is not a field or method of {node.parent.name}"
                 assert not (field and method)
                 node.typ = value
+            case ir.ConstRef():
+                self.check(node.value)
+                node.typ = self.update_types(node.typ, node.value.typ)
             case ir.Ref():
                 pass
             case _:

--- a/src/python/type_checker.py
+++ b/src/python/type_checker.py
@@ -32,8 +32,6 @@ class DeferChecking(Exception):
 
 class TypeChecker:
     def __init__(self, error_handler=None):
-        # used to infer return types
-        self.function = None
         self.error_handler = error_handler
         self.deferred = []
 

--- a/test/test_lexer.py
+++ b/test/test_lexer.py
@@ -17,6 +17,7 @@ class TestLexer(unittest.TestCase):
             "while": [Token(T.WHILE, "while", start_pos)],
             "return": [Token(T.RETURN, "return", start_pos)],
             "var": [Token(T.VAR, "var", start_pos)],
+            "const": [Token(T.CONST, "const", start_pos)],
             "fn": [Token(T.FUNC, "fn", start_pos)],
             "struct": [Token(T.STRUCT, "struct", start_pos)],
             "interface": [Token(T.INTERFACE, "interface", start_pos)],


### PR DESCRIPTION
Adds constants names, and allows them to be declared globally. Variables cannot be declared globally. Fixes #29 